### PR TITLE
updated package.json with socket.io v0.9.17 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "main": "port",
   "devDependencies": {
     "mocha": "1.19.0",
-    "expect.js": "0.3.1"
+    "expect.js": "0.3.1",
+    "socket.io": "^0.9.17"
   },
   "licenses": [
     {
@@ -34,6 +35,5 @@
     "url": "https://github.com/thisconnect/port/issues"
   },
   "dependencies": {
-    "socket.io": "^0.9.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,32 +1,39 @@
 {
-	"name": "port"
-	, "version": "0.8.0"
-	, "author": "Enrique Erne (http://mild.ch/)"
-	, "description": "Spawn Pd (Pure Data) and communicate through TCP sockets"
-	, "keywords": [
-		"puredata"
-		, "pd"
-		, "fudi"
-		, "tcp"
-		, "dsp"
-		, "signal"
-		, "audio"
-	]
-	, "repository": "git://github.com/thisconnect/port.git"
-	, "homepage": "https://github.com/thisconnect/port"
-	, "contributors": [
-		{"name": "Enrique Erne"}
-	]
-	, "main": "port"
-	, "devDependencies": {
-		"mocha": "1.19.0"
-		, "expect.js": "0.3.1"
-	}
-	, "licenses": [{
-		"type": "MIT"
-		, "url": "https://raw.github.com/thisconnect/port/master/license"
-	}]
-	, "bugs": {
-		"url": "https://github.com/thisconnect/port/issues"
-	}
+  "name": "port",
+  "version": "0.8.0",
+  "author": "Enrique Erne (http://mild.ch/)",
+  "description": "Spawn Pd (Pure Data) and communicate through TCP sockets",
+  "keywords": [
+    "puredata",
+    "pd",
+    "fudi",
+    "tcp",
+    "dsp",
+    "signal",
+    "audio"
+  ],
+  "repository": "git://github.com/thisconnect/port.git",
+  "homepage": "https://github.com/thisconnect/port",
+  "contributors": [
+    {
+      "name": "Enrique Erne"
+    }
+  ],
+  "main": "port",
+  "devDependencies": {
+    "mocha": "1.19.0",
+    "expect.js": "0.3.1"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://raw.github.com/thisconnect/port/master/license"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/thisconnect/port/issues"
+  },
+  "dependencies": {
+    "socket.io": "^0.9.17"
+  }
 }


### PR DESCRIPTION
the examples break with the latest socket.io version (which is installed by default)

ultimate todo: patch examples to work with latest socket.io
